### PR TITLE
Debug Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ The retrieve function is essentially a shadow of the highline ask function, exce
     end
 ```
 
+### Print stacktraces for errors
+To get more information while debugging you may activate the debug mode. The gem will print the stacktraces for exceptions while in debug mode.
+
+```ruby
+    Steps::Output.set_debug true
+```
+
+
 ### Capistrano Deployment Integration
 
 If you want to quiet down your Capistrano output and use this to provide the output, you can manually quiet the Capistrano logger and use this gem in the following way.

--- a/lib/steps/output.rb
+++ b/lib/steps/output.rb
@@ -11,6 +11,11 @@ module Steps
     @task_depth = 0
     @stacked_result = false
     @highline = HighLine.new
+    @debug = false
+ 
+    def self.set_debug(debug)
+      @debug = debug
+    end
 
     def self.step(desc, options)
       self.start_to desc
@@ -22,6 +27,12 @@ module Steps
           message = e.message.empty? ? "X" : e.message
 
           self.error(message)
+          if @debug
+            puts
+            puts "Backtrace:"
+            puts e.backtrace
+            puts
+          end
           if options[:vital]
             if @task_depth > 1
               raise "X"


### PR DESCRIPTION
Since the steps gem just displays the exception message without the backtrace, it's pretty hard to debug while developing with the gem.

I added a debug mode, which may be activated via

``` ruby
    Steps::Output.set_debug true
```

and causes the gem to print the stacktraces too.
