### PR TITLE
Don't print stacktraces of SystemExit exceptions

### DIFF
--- a/lib/steps/output.rb
+++ b/lib/steps/output.rb
@@ -28,7 +28,7 @@ module Steps
       rescue Exception => e
           message = e.message.empty? ? "X" : e.message
 
-          if @task_depth >= @debug_depth
+          if !e.is_a?(SystemExit) and @task_depth >= @debug_depth
             report message, "red", false
             e.backtrace.each { |c| report("(debug) #{c}", "red") }
             message = "X"

--- a/lib/steps/output.rb
+++ b/lib/steps/output.rb
@@ -28,13 +28,16 @@ module Steps
       rescue Exception => e
           message = e.message.empty? ? "X" : e.message
 
-          if !e.is_a?(SystemExit) and @task_depth >= @debug_depth
-            report message, "red", false
-            e.backtrace.each { |c| report("(debug) #{c}", "red") }
-            message = "X"
+          unless e.is_a?(SystemExit) 
+            if @task_depth >= @debug_depth
+              report message, "red", false
+              e.backtrace.each { |c| report("(debug) #{c}", "red") }
+              message = "X"
+            end
+
+            self.error(message)
           end
 
-          self.error(message)
           if options[:vital]
             if @task_depth > 1
               raise "X"


### PR DESCRIPTION
Especially because output.rb:42 (:45 after merge) calls exit.

(Now without bugs)
