### PR TITLE
Add default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,3 +28,4 @@ Jeweler::Tasks.new do |gem|
 end
 Jeweler::RubygemsDotOrgTasks.new
 
+task :default => [:clobber, :build]


### PR DESCRIPTION
Adds a default task so you can say `bundle exec rake` and get a build after cloning the repository.
