### PR TITLE
Bundle rake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ group :development do
   gem "rspec", "~> 2.11"
   gem "bundler", "~> 1.0"
   gem "jeweler", "~> 1.8"
+  gem "rake", "~> 10.1.0"
   gem "simplecov", ">= 0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       rdoc
     json (1.8.0)
     multi_json (1.7.7)
-    rake (10.0.4)
+    rake (10.1.0)
     rdoc (4.0.1)
       json (~> 1.4)
     rspec (2.13.0)
@@ -36,5 +36,6 @@ DEPENDENCIES
   colored (>= 1.2)
   highline (>= 1.6)
   jeweler (~> 1.8)
+  rake (~> 10.1.0)
   rspec (~> 2.11)
   simplecov

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'rubygems'
 require 'bundler'
 begin
   Bundler.setup(:default, :development)
@@ -9,7 +8,6 @@ rescue Bundler::BundlerError => e
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
 end
-require 'rake'
 
 require 'jeweler'
 Jeweler::Tasks.new do |gem|


### PR DESCRIPTION
Add `rake` to the list of development dependencies, so `bundle exec rake` is always using a known version, rather than whatever comes with the ruby installation.
