### PR TITLE
Ignore binstubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.ruby-version
 coverage
 InstalledFiles
 lib/bundler/man

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .ruby-version
+bin/
 coverage
 InstalledFiles
 lib/bundler/man


### PR DESCRIPTION
Ignore the `bin/` directory so `bundle install --path .bundle/gems --binstubs` works nicely.  Also ignore `.ruby-version` so the local version can be switched easily for testing with rbenv.
